### PR TITLE
Upgrade aws provider to 6.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "this" {
 }
 
 locals {
-  region = coalesce(var.region, data.aws_region.current.name)
+  region = coalesce(var.region, data.aws_region.current.region)
 
   application_id = coalesce(
     var.application_id,

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
Upgrading our internal terraform to use the latest AWS provider, so also have to update dependencies.